### PR TITLE
Handle a create statement with a quoted newline

### DIFF
--- a/lib/schema_plus/core/sql_struct.rb
+++ b/lib/schema_plus/core/sql_struct.rb
@@ -14,7 +14,7 @@ module SchemaPlus
             \) \s*
             (?<options> \S.*)?
             $
-          }xi
+          }mxi
           self.command = m[:command]
           self.quotechar = m[:quote]
           self.name = m[:name]

--- a/spec/sql_struct_spec.rb
+++ b/spec/sql_struct_spec.rb
@@ -24,6 +24,12 @@ describe SchemaPlus::Core::SqlStruct do
       Then { expect(struct.options).to be_blank }
     end
 
+    context "a table with quoted newline" do
+      Given(:sql) { %q<CREATE TABLE \"things\" (\"id\" serial primary key, \"name\" character varying DEFAULT 'hey\nhey') >}
+      Then { expect(struct.command).to eq "CREATE TABLE" }
+      Then { expect(struct.name).to eq "things" }
+    end
+
   end
 
 end

--- a/spec/sql_struct_spec.rb
+++ b/spec/sql_struct_spec.rb
@@ -25,7 +25,7 @@ describe SchemaPlus::Core::SqlStruct do
     end
 
     context "a table with quoted newline" do
-      Given(:sql) { %q<CREATE TABLE \"things\" (\"id\" serial primary key, \"name\" character varying DEFAULT 'hey\nhey') >}
+      Given(:sql) { %q<CREATE TABLE "things" ("id" serial primary key, "name" character varying DEFAULT 'hey\nhey') >}
       Then { expect(struct.command).to eq "CREATE TABLE" }
       Then { expect(struct.name).to eq "things" }
     end

--- a/spec/sql_struct_spec.rb
+++ b/spec/sql_struct_spec.rb
@@ -25,7 +25,7 @@ describe SchemaPlus::Core::SqlStruct do
     end
 
     context "a table with quoted newline" do
-      Given(:sql) { %q<CREATE TABLE "things" ("id" serial primary key, "name" character varying DEFAULT 'hey\nhey') >}
+      Given(:sql) { %q<CREATE TABLE "things" ("id" serial primary key, "name" character varying DEFAULT 'hey\nhey')>}
       Then { expect(struct.command).to eq "CREATE TABLE" }
       Then { expect(struct.name).to eq "things" }
     end


### PR DESCRIPTION
I was trying to load a schema which contained a newline in the default value for a string column which was choking the regex here.