### PR TITLE
Update prepare_column_options to work with AR 5

### DIFF
--- a/lib/schema_plus/core/active_record/connection_adapters/postgresql_adapter.rb
+++ b/lib/schema_plus/core/active_record/connection_adapters/postgresql_adapter.rb
@@ -16,7 +16,7 @@ module SchemaPlus
           # expressions don't work well in AR anyway.  (hence
           # schema_plus_default_expr )
           #
-          def prepare_column_options(column, types) # :nodoc:
+          def prepare_column_options(column, *) # :nodoc:
             spec = super
             spec[:default] = "%q{#{column.default_function}}" if column.default_function
             spec

--- a/schema_plus_core.gemspec
+++ b/schema_plus_core.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency "activerecord", ">= 4.2"
+  gem.add_dependency "activerecord", ">= 4.2", "< 6"
   gem.add_dependency "schema_monkey", "~> 2.1"
 
   gem.add_development_dependency "bundler", "~> 1.7"

--- a/spec/column_spec.rb
+++ b/spec/column_spec.rb
@@ -39,7 +39,7 @@ describe SchemaMonkey::Middleware::Migration::Column do
 
     context "when add ordinary column" do
       When { migration.create_table("things") { |t| t.integer "test_column" } }
-      Then { expect(spy).to eq [
+      Then { expect(spy).to match_array [
         { column_name: "id", type: :primary_key, implements_reference: nil },
         { column_name: "test_column", type: :integer, implements_reference: nil }
       ] }
@@ -49,7 +49,7 @@ describe SchemaMonkey::Middleware::Migration::Column do
 
       context "when add reference using t.#{method}" do
         When { migration.create_table("things") { |t| t.send method, "test_reference" } }
-        Then { expect(spy).to eq [
+        Then { expect(spy).to match_array [
           { column_name: "id", type: :primary_key, implements_reference: nil },
           { column_name: "test_reference_id", type: :reference, implements_reference: nil },
           { column_name: "test_reference_id", type: :integer, implements_reference: true }
@@ -58,7 +58,7 @@ describe SchemaMonkey::Middleware::Migration::Column do
 
       context "when add polymorphic reference using t.#{method}" do
         When { migration.create_table("things") { |t| t.send method, "test_reference", polymorphic: true } }
-        Then { expect(spy).to eq [
+        Then { expect(spy).to match_array [
           { column_name: "id", type: :primary_key, implements_reference: nil },
           { column_name: "test_reference_id", type: :reference, implements_reference: nil },
           { column_name: "test_reference_id", type: :integer, implements_reference: true },
@@ -76,7 +76,7 @@ describe SchemaMonkey::Middleware::Migration::Column do
       context "when add reference using migration.add_reference" do
 
         When { migration.add_reference("things", "test_reference") }
-        Then { expect(spy).to eq [
+        Then { expect(spy).to match_array [
           { column_name: "test_reference_id", type: :reference, implements_reference: nil },
           { column_name: "test_reference_id", type: :integer, implements_reference: true }
         ] }
@@ -87,7 +87,7 @@ describe SchemaMonkey::Middleware::Migration::Column do
         When {
           migration.add_reference("things", "test_reference", polymorphic: true)
         }
-        Then { expect(spy).to eq [
+        Then { expect(spy).to match_array [
           { column_name: "test_reference_id", type: :reference, implements_reference: nil },
           { column_name: "test_reference_id", type: :integer, implements_reference: true },
           { column_name: "test_reference_type", type: :string, implements_reference: true }


### PR DESCRIPTION
Also includes an update to the version range to limit to AR < 6 (cf. https://github.com/SchemaPlus/schema_monkey/pull/11) as well as some updates to the specs that relate to the order that AR 5 returns columns for polymorphic references.