### PR TITLE
fix a serial pk on rails 5.2+

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,6 +444,7 @@ SchemaPlus::Core provides a state object and of callbacks to various phases of t
 
 ## Release Notes
 
+* 2.2.2 Fixed dumping tables in postgresql in AR 5.2 when the PK is not a bigint.
 * 2.2.1 Fixed expression index handling in AR5.x.
 * 2.2.0 Added AR5.2 support.  Thanks to [@jeremyyap](https://github.com/jeremyyap)
 * 2.1.1 Bug fix: Don't lose habtm options.  Thanks to [@iagopiimenta ](https://github.com/iagopiimenta)

--- a/lib/schema_plus/core.rb
+++ b/lib/schema_plus/core.rb
@@ -26,7 +26,7 @@ require_relative "core/schema_dump"
 require_relative "core/sql_struct"
 require_relative "core/version"
 
-if ActiveRecord.version >= Gem::Version.new('5.2.0.rc1')
+if ActiveRecord.version >= Gem::Version.new('5.2')
   require_relative "core/active_record/connection_adapters/postgresql/schema_dumper"
 end
 

--- a/lib/schema_plus/core/active_record/connection_adapters/postgresql/schema_dumper.rb
+++ b/lib/schema_plus/core/active_record/connection_adapters/postgresql/schema_dumper.rb
@@ -5,7 +5,6 @@ module SchemaPlus
         module PostgreSQL
           module PostgreSQL # need two PostgreSQLs because the first gets stripped by schema_monkey
             module SchemaDumper
-
               # quick hack fix quoting of column default functions to allow eval() when we
               # capture the stream.
               #
@@ -20,7 +19,7 @@ module SchemaPlus
               #
               def prepare_column_options(column, *) # :nodoc:
                 spec = super
-                spec[:default] = "%q{#{column.default_function}}" if column.default_function
+                spec[:default] = "%q{#{column.default_function}}" if column.default_function && !column.serial?
                 spec
               end
 

--- a/lib/schema_plus/core/version.rb
+++ b/lib/schema_plus/core/version.rb
@@ -1,5 +1,5 @@
 module SchemaPlus
   module Core
-    VERSION = "2.2.1"
+    VERSION = "2.2.2"
   end
 end

--- a/spec/dumper_spec.rb
+++ b/spec/dumper_spec.rb
@@ -82,6 +82,15 @@ describe SchemaMonkey::Middleware::Dumper do
 
   context TestDumper::Middleware::Dumper::Tables do
     Then { expect(dump).to match(/create_table "other".*create_table "#{middleware}".*create_table "things"/m) }
+
+    context 'int PK handling in rails 5.2+', postgresql: :only, rails: ['>= 5.2.0'] do
+      before(:each) do
+        migration.create_table "inttable", id: :serial do |t|
+        end
+      end
+
+      Then { expect(dump).to_not match(/create_table "inttable", id: :serial.*default:/m) }
+    end
   end
 
   context TestDumper::Middleware::Dumper::Table do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,12 @@ Dir[File.dirname(__FILE__) + "/support/**/*.rb"].each {|f| require f}
 SchemaDev::Rspec.setup
 
 RSpec.configure do |config|
+
+  config.filter_run_excluding rails: -> (v) {
+    rails_version = Gem::Version.new(ActiveRecord::VERSION::STRING)
+    test = Gem::Requirement.new(v)
+    !test.satisfied_by?(rails_version)
+  }
   config.warnings = true
   config.around(:each) do |example|
     ActiveRecord::Migration.suppress_messages do


### PR DESCRIPTION
Fixes issue where the serial gets put in the PK defintion incorrectly. (#22)

fixing this for Rails 5.1 is non-trivial as things are broken in AR 5.1