### PR TITLE
fix dumping expression indexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,6 +444,7 @@ SchemaPlus::Core provides a state object and of callbacks to various phases of t
 
 ## Release Notes
 
+* 2.2.3 Fix dumping complex expression based indexes in AR 5.x
 * 2.2.2 Fixed dumping tables in postgresql in AR 5.2 when the PK is not a bigint.
 * 2.2.1 Fixed expression index handling in AR5.x.
 * 2.2.0 Added AR5.2 support.  Thanks to [@jeremyyap](https://github.com/jeremyyap)

--- a/lib/schema_plus/core/active_record/schema_dumper.rb
+++ b/lib/schema_plus/core/active_record/schema_dumper.rb
@@ -44,6 +44,54 @@ module SchemaPlus
           end
         end
 
+        TABLE_COLUMN_MATCHES = [
+            [ # first match expression index case
+                %r{
+                  ^
+                  t\.index \s*
+                    "(?<index_cols>(?:[^"\\]|\\.)*?)" \s*
+                    , \s*
+                    name\: \s* [:'"](?<name>[^"\s]+)[,"]? \s*
+                    ,? \s*
+                    (?<options>.*)
+                  $
+                  }x,
+                ->(m) {
+                  index_cols = m[:index_cols].gsub('\\"', '"')
+                  SchemaDump::Table::Index.new name: m[:name], columns: index_cols, options: eval("{" + m[:options] + "}")
+                }
+            ],
+            [ # general matching of columns
+                %r{
+                  ^
+                  t\.(?<type>\S+) \s*
+                    [:'"](?<name>[^"\s]+)[,"]? \s*
+                    ,? \s*
+                    (?<options>.*)
+                  $
+                  }x,
+                ->(m) {
+                  SchemaDump::Table::Column.new name: m[:name], type: m[:type], options: eval("{" + m[:options] + "}"), comments: []
+                }
+            ],
+            [ # index definitions with multiple columns
+                %r{
+                  ^
+                  t\.index \s*
+                    \[(?<index_cols>.*?)\] \s*
+                    , \s*
+                    name\: \s* [:'"](?<name>[^"\s]+)[,"]? \s*
+                    ,? \s*
+                    (?<options>.*)
+                  $
+                  }x,
+                ->(m) {
+                  index_cols = m[:index_cols].tr(%q{'":}, '').strip.split(/\s*,\s*/)
+                  SchemaDump::Table::Index.new name: m[:name], columns: index_cols, options: eval("{#{m[:options]}}")
+                }
+            ]
+        ].freeze
+
         def table(table, _)
           SchemaMonkey::Middleware::Dumper::Table.start(dumper: self, connection: @connection, dump: @dump, table: @dump.tables[table] = SchemaDump::Table.new(name: table)) do |env|
             stream = StringIO.new
@@ -68,34 +116,13 @@ module SchemaPlus
               env.table.trailer = m[:trailer].split("\n").map(&:strip).reject{|s| s.blank?}
               table_objects = m[:columns].strip.split("\n").map { |col|
                 cs = col.strip
-                m = cs.match %r{
-                ^
-                t\.(?<type>\S+) \s*
-                  [:'"](?<name>[^"\s]+)[,"]? \s*
-                  ,? \s*
-                  (?<options>.*)
-                $
-                }x
-                if !m.nil?
-                  SchemaDump::Table::Column.new name: m[:name], type: m[:type], options: eval("{" + m[:options] + "}"), comments: []
-                else
-                  m = cs.match %r{
-                  ^
-                  t\.index \s*
-                    \[(?<index_cols>.*?)\] \s*
-                    , \s*
-                    name\: \s* [:'"](?<name>[^"\s]+)[,"]? \s*
-                    ,? \s*
-                    (?<options>.*)
-                  $
-                  }x
-                  if m.nil?
-                    nil
-                  else
-                    index_cols = m[:index_cols].tr(%q{'":}, '').strip.split(/\s*,\s*/)
-                    SchemaDump::Table::Index.new name: m[:name], columns: index_cols, options: eval("{#{m[:options]}}")
-                  end
+                result = nil
+                # find the first regex that matches and grab the column definition
+                TABLE_COLUMN_MATCHES.find do |(r, l)|
+                  m = cs.match r
+                  result = m.nil? ? nil : l.call(m)
                 end
+                result
               }.reject { |o| o.nil? }
               env.table.columns = table_objects.select { |o| o.is_a? SchemaDump::Table::Column }
               env.table.indexes = table_objects.select { |o| o.is_a? SchemaDump::Table::Index }

--- a/lib/schema_plus/core/version.rb
+++ b/lib/schema_plus/core/version.rb
@@ -1,5 +1,5 @@
 module SchemaPlus
   module Core
-    VERSION = "2.2.2"
+    VERSION = "2.2.3"
   end
 end

--- a/spec/dumper_spec.rb
+++ b/spec/dumper_spec.rb
@@ -91,6 +91,20 @@ describe SchemaMonkey::Middleware::Dumper do
 
       Then { expect(dump).to_not match(/create_table "inttable", id: :serial.*default:/m) }
     end
+
+    context 'expression index handling', postgresql: :only do
+      before(:each) do
+        migration.create_table "expressions" do |t|
+          t.string :field
+          t.string :column
+          t.index 'lower(field), id', name: 'index_expression_field'
+          t.index 'lower("column"), id', name: 'index_expression_column'
+        end
+      end
+
+      Then { expect(dump).to match(/index "lower.+field.+, id", :name=>"index_expression_field"/) }
+      Then { expect(dump).to match(/index "lower.+"column\\".+, id", :name=>"index_expression_column"/) }
+    end
   end
 
   context TestDumper::Middleware::Dumper::Table do


### PR DESCRIPTION
Fixes scenario where the dumper fails with an expression index exists for multiple columns.

```ruby
t.index "date(created_at), id", name: "index_expression", where: "status = 0"
```
