### PR TITLE
Support for default procs

### DIFF
--- a/lib/schema_plus/core/schema_dump.rb
+++ b/lib/schema_plus/core/schema_dump.rb
@@ -105,6 +105,11 @@ module SchemaPlus
               pr += ',' unless options.blank?
               stream.write "%-#{namelen+3}s " % pr
             end
+            if options[:default].is_a?(Proc)
+              default = options.delete(:default)
+              stream.write "default: -> { \"#{default.call}\" }, "
+              stream.write options.to_s.sub(/^{(.*)}$/, '\1') unless options.blank?
+            end
             stream.write options.to_s.sub(/^{(.*)}$/, '\1') unless options.blank?
             stream.write ' ' unless options.blank? or comments.blank?
             stream.write '# ' + comments.join('; ') unless comments.blank?

--- a/lib/schema_plus/core/schema_dump.rb
+++ b/lib/schema_plus/core/schema_dump.rb
@@ -105,10 +105,12 @@ module SchemaPlus
               pr += ',' unless options.blank?
               stream.write "%-#{namelen+3}s " % pr
             end
-            if options[:default].is_a?(Proc)
-              default = options.delete(:default)
-              stream.write "default: -> { \"#{default.call}\" }"
-              stream.write ", " unless options.blank?
+            if Gem::Version.new(ActiveRecord::VERSION::STRING) >= Gem::Version.new('5.0.0')
+              if options[:default].is_a?(Proc) && 
+                default = options.delete(:default)
+                stream.write "default: -> { \"#{default.call}\" }"
+                stream.write ", " unless options.blank?
+              end
             end
             stream.write options.to_s.sub(/^{(.*)}$/, '\1') unless options.blank?
             stream.write ' ' unless options.blank? or comments.blank?

--- a/lib/schema_plus/core/schema_dump.rb
+++ b/lib/schema_plus/core/schema_dump.rb
@@ -105,7 +105,7 @@ module SchemaPlus
               pr += ',' unless options.blank?
               stream.write "%-#{namelen+3}s " % pr
             end
-            if Gem::Version.new(ActiveRecord::VERSION::STRING) >= Gem::Version.new('5.0.0')
+            if Gem::Version.new(::ActiveRecord::VERSION::STRING) >= Gem::Version.new('5.0.0')
               if options[:default].is_a?(Proc) && 
                 default = options.delete(:default)
                 stream.write "default: -> { \"#{default.call}\" }"

--- a/lib/schema_plus/core/schema_dump.rb
+++ b/lib/schema_plus/core/schema_dump.rb
@@ -107,8 +107,8 @@ module SchemaPlus
             end
             if options[:default].is_a?(Proc)
               default = options.delete(:default)
-              stream.write "default: -> { \"#{default.call}\" }, "
-              stream.write options.to_s.sub(/^{(.*)}$/, '\1') unless options.blank?
+              stream.write "default: -> { \"#{default.call}\" }"
+              stream.write ", " unless options.blank?
             end
             stream.write options.to_s.sub(/^{(.*)}$/, '\1') unless options.blank?
             stream.write ' ' unless options.blank? or comments.blank?


### PR DESCRIPTION
The column :default can be a Proc. This supports the new syntax.

Relevant issues:
https://github.com/SchemaPlus/schema_plus_core/issues/28
https://github.com/SchemaPlus/schema_validations/issues/71
