### PR TITLE
Support whitespaces in definitions

### DIFF
--- a/lib/schema_plus/core/active_record/schema_dumper.rb
+++ b/lib/schema_plus/core/active_record/schema_dumper.rb
@@ -79,7 +79,7 @@ module SchemaPlus
                 %r{
                   ^
                   t\.(?<type>\S+) \s*
-                    [:'"](?<name>[^"\s]+)[,"]? \s*
+                    (:(?<name>[a-z_]+)|"(?<name>[^"]+)"|'(?<name>[^']+)') \s*
                     ,? \s*
                     (?<options>.*)
                   $

--- a/spec/dumper_spec.rb
+++ b/spec/dumper_spec.rb
@@ -79,6 +79,14 @@ describe SchemaMonkey::Middleware::Dumper do
     Then { expect(dump use_middleware: false).to match(/\\"substring\\"\(\(random/) }
   end
 
+  context "column with a whitespace", postgresql: :only do
+    before(:each) do
+      migration.execute %Q{ALTER TABLE "things" ADD "whitespaced column" integer}
+    end
+
+    Then { expect(dump use_middleware: false).to include('t.integer "whitespaced column"') }
+  end
+
   context TestDumper::Middleware::Dumper::Initial do
     Then { expect(dump).to match(/Schema([\[\].0-9]+)?[.]define.*do\s+#{middleware}/) }
   end


### PR DESCRIPTION
Trying to support Rails 6.1 which now has `t.check_constraint "some long statement"`, but I am too unfamiliar with the development environment to include Rails-version specific code; so for now, I just deduced (and tested on a local project) that solving https://github.com/SchemaPlus/schema_plus_core/issues/16 will help.

The fix is to use more robust regexp for column name detection in Rails-generated statements.

The PR seems to work, both practically (when included locally in Rails 6.1+ project with constraints in DB), and in tests that are related to my changes.

I am not sure why SQLite tests fail on CI, but I am almost sure that it is unrelated:

```
can't activate sqlite3 (~> 1.4), already activated sqlite3-2.0.4. Make sure all dependencies are added to Gemfile.
```

Please advise how to proceed with this PR.